### PR TITLE
Use the PWD of the current Go file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.4
+
+- When running `goimports`, use the current file's directory as PWD. This prevents it from occassionally failing to add imports.
+
 ## v0.1.3
 
 - Saves and restores the scroll position to avoid the view jumping.


### PR DESCRIPTION
Using the default PWD (the location of Sublime's binary) sometimes causes `goimports` to fail to add new imports; setting the PWD to the Go directory prevents that.